### PR TITLE
Fix graph layout on graph data update

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ Future work will include more support for 3rd party Cytoscape plugins. Currently
 have to get access to the module's exposed "cy" object:
 
 ```typescript
+export class MyComponent implements OnInit, ngAfterViewInit {
+
+  // Get reference to the native element cytoscape instance 
+  @ViewChild('cytoscape') cytoscape: any;
+
+  // ...
+
   ngAfterViewInit() {
       if (this.cytograph.cy) {
         const cyLayer = this.cytograph.cy.cyCanvas();

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Future work will include more support for 3rd party Cytoscape plugins. Currently
 have to get access to the module's exposed "cy" object:
 
 ```typescript
+import { Component, OnInit, ViewChild } from '@angular/core';
+
+// ...
+
 export class MyComponent implements OnInit, ngAfterViewInit {
 
   // Get reference to the native element cytoscape instance 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # ngx-cytoscape
+nmb-NGX-Cytoscape is some simple bugfixes applied to NGX-Cytoscape.  See PR 
+https://github.com/calvinvette/ngx-cytoscape/pull/1 
 
 NGX-Cytoscape is an Angular 5+ wrapper around the CytoscapeJS 3 module based on original work from Michael Knoch.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-cytoscape",
+  "name": "nmb-ngx-cytoscape",
   "version": "0.5.23",
   "scripts": {
     "build": "gulp build",
@@ -16,11 +16,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/calvinvette/ngx-cytoscape"
+    "url": "https://github.com/nmbradford/ngx-cytoscape"
   },
   "author": {
-    "name": "Calvin Vette",
-    "email": "calvinvette@gmail.com"
+    "name": "Nick Bradford",
+    "email": "nick@cloud-geek.com"
   },
   "keywords": [
     "angular",
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/calvinvette/ngx-cytoscape/issues"
+    "url": "https://github.com/nmbradford/ngx-cytoscape/issues"
   },
   "peerDependencies": {
     "@types/cytoscape": "^3.1.6",

--- a/src/cytoscape.ts
+++ b/src/cytoscape.ts
@@ -38,7 +38,7 @@ export class CytoscapeComponent implements OnChanges {
             .selector('node')
             .css({
                 'content': 'data(name)',
-                'shape': 'rectangle',
+                'shape': 'data(faveShape)',
                 'text-valign': 'center',
                 'background-color': 'data(faveColor)',
                 'width': '200px',

--- a/src/cytoscape.ts
+++ b/src/cytoscape.ts
@@ -89,14 +89,27 @@ export class CytoscapeComponent implements OnChanges {
                 elements: this.elements,
             });
         } else {
-            this.cy.layout = this.layout;
+
+            // Have to stop existing layout instance.
+            let oldlayout = this.cy.LayoutInstance;
+            if ( oldlayout) {
+                oldlayout.stop();
+            }
+
+            // this.cy.layout = this.layout;
             // this.cy.nodes().forEach(node => {
             //     node.remove();
             // });
             this.cy.nodes().remove();
-            this.cy.add(this.elements);
+            let nodes = this.cy.add(this.elements);
             this.cy.minZoom(this.zoom.min);
             this.cy.maxZoom(this.zoom.max);
+
+            // set the current graph elem collection layout to current instance value.
+            let layout = nodes.layout(this.layout);
+
+            // we need to rerun the layout again
+            layout.run();
         }
     }
 


### PR DESCRIPTION
Resolves issue redefining elements causing specified layout style to not be applied.
Minor documentation updates to include how to get reference to cytoscape instance created within template from component code.